### PR TITLE
Fix sending of mono path

### DIFF
--- a/.github/workflows/update-monorepository.yml
+++ b/.github/workflows/update-monorepository.yml
@@ -3,16 +3,16 @@ on:
   push:
     branches:
       - master
+env:
+  REPOSITORY_MONO_PATH: collector
 jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
       - name: Mono repository update
         uses: peter-evans/repository-dispatch@v1
-        env:
-          REPOSITORY_MONO_PATH: collector
         with:
-          token: ${{ secrets.HAWK_MONO_REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.MONO_TOKEN }}
           event-type: submodule-changed
           repository: codex-team/hawk.mono
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "path": "${REPOSITORY_MONO_PATH}"}'
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "path": "${{ env.REPOSITORY_MONO_PATH }}"}'


### PR DESCRIPTION
Now dispatch event uses path for commit message generation. Bug with empty path fixed.