### PR TITLE
debug(sentry): add debug log for sentry key error

### DIFF
--- a/pkg/server/errorshandler/sentry_utils.go
+++ b/pkg/server/errorshandler/sentry_utils.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-  "log"
 	"strings"
+  log "github.com/sirupsen/logrus"
 )
 
 func decompressGzipString(gzipString []byte) ([]byte, error) {

--- a/pkg/server/errorshandler/sentry_utils.go
+++ b/pkg/server/errorshandler/sentry_utils.go
@@ -35,7 +35,7 @@ func getSentryKeyFromAuth(auth string) (string, error) {
 		}
 	}
 
-	log.Debugf("Sentry key not found in auth header: %s", auth)
+	log.Infof("Sentry key not found in auth header: %s", auth)
 
 	return "", errors.New("sentry_key not found")
 }

--- a/pkg/server/errorshandler/sentry_utils.go
+++ b/pkg/server/errorshandler/sentry_utils.go
@@ -35,5 +35,7 @@ func getSentryKeyFromAuth(auth string) (string, error) {
 		}
 	}
 
+	log.Debugf("Sentry key not found in auth header: %s", auth)
+
 	return "", errors.New("sentry_key not found")
 }

--- a/pkg/server/errorshandler/sentry_utils.go
+++ b/pkg/server/errorshandler/sentry_utils.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+  "log"
 	"strings"
 )
 


### PR DESCRIPTION
debug `sentry_key` not found error

check format of the string with `sentry_key`