### PR TITLE
Fix race condition caused by concurrent map read and map write

### DIFF
--- a/pkg/accounts/cache.go
+++ b/pkg/accounts/cache.go
@@ -66,7 +66,7 @@ func (client *AccountsMongoDBClient) UpdateTokenCache() error {
 		return err
 	}
 
-	// Create a temporary map instead of directly modifying client.ValidTokens
+	// Create a temporary map instead of directly modifying client.validTokens
 	validTokensTmp := make(map[string]string)
 	
 	for _, project := range projects {
@@ -79,10 +79,10 @@ func (client *AccountsMongoDBClient) UpdateTokenCache() error {
 	}
 	
 	// Atomically replace the map reference
-	client.ValidTokens = validTokensTmp
+	client.validTokens = validTokensTmp
 
-	log.Debugf("Cache for MongoDB tokens successfully updates with %d tokens", len(client.ValidTokens))
-	log.Tracef("Current token cache state: %s", client.ValidTokens)
+	log.Debugf("Cache for MongoDB tokens successfully updates with %d tokens", len(client.validTokens))
+	log.Tracef("Current token cache state: %s", client.validTokens)
 
 	return nil
 }
@@ -141,7 +141,7 @@ func (client *AccountsMongoDBClient) UpdateProjectsLimitsCache() error {
 		workspaceMap[workspace.WorkspaceID.Hex()] = workspace
 	}
 
-	// Create a temporary map instead of directly modifying client.ProjectLimits
+	// Create a temporary map instead of directly modifying client.projectLimits
 	projectLimitsTmp := make(map[string]rateLimitSettings)
 
 	// Process each project applying the priority rules
@@ -169,14 +169,14 @@ func (client *AccountsMongoDBClient) UpdateProjectsLimitsCache() error {
 			finalLimits.EventsPeriod = project.RateLimitSettings.EventsPeriod
 		}
 
-		// Add to temporary map instead of client.ProjectLimits
+		// Add to temporary map instead of client.projectLimits
 		projectLimitsTmp[projectID] = finalLimits
 	}
 
 	// Atomically replace the map reference
-	client.ProjectLimits = projectLimitsTmp
+	client.projectLimits = projectLimitsTmp
 
-	log.Tracef("Current projects limits cache state: %+v", client.ProjectLimits)
+	log.Tracef("Current projects limits cache state: %+v", client.projectLimits)
 
 	return nil
 }

--- a/pkg/accounts/mongodb.go
+++ b/pkg/accounts/mongodb.go
@@ -21,8 +21,8 @@ type AccountsMongoDBClient struct {
 	mdb           *mongo.Client
 	ctx           context.Context
 	database      string
-	ValidTokens   map[string]string
-	ProjectLimits map[string]rateLimitSettings
+	validTokens   map[string]string
+	projectLimits map[string]rateLimitSettings
 }
 
 func New(connectionURI string) *AccountsMongoDBClient {
@@ -59,4 +59,16 @@ func (m *AccountsMongoDBClient) CheckAvailability() bool {
 	defer cancel()
 	err := m.mdb.Ping(ctx, readpref.Primary())
 	return err == nil
+}
+
+// GetValidToken returns the project ID for a given integration token
+func (client *AccountsMongoDBClient) GetValidToken(token string) (string, bool) {
+	projectID, ok := client.validTokens[token]
+	return projectID, ok
+}
+
+// GetProjectLimits returns the rate limit settings for a project
+func (client *AccountsMongoDBClient) GetProjectLimits(projectID string) (rateLimitSettings, bool) {
+	limits, ok := client.projectLimits[projectID]
+	return limits, ok
 }

--- a/pkg/server/errorshandler/handler.go
+++ b/pkg/server/errorshandler/handler.go
@@ -58,14 +58,14 @@ func (handler *Handler) process(body []byte) ResponseMessage {
 		return ResponseMessage{400, true, "Token decoding error"}
 	}
 
-	projectId, ok := handler.AccountsMongoDBClient.ValidTokens[integrationSecret]
+	projectId, ok := handler.AccountsMongoDBClient.GetValidToken(integrationSecret)
 	if !ok {
 		log.Debugf("Token %s is not in the accounts cache", integrationSecret)
 		return ResponseMessage{400, true, fmt.Sprintf("Integration token invalid: %s", integrationSecret)}
 	}
 	log.Debugf("Found project with ID %s for integration token %s", projectId, integrationSecret)
 
-	projectLimits, ok := handler.AccountsMongoDBClient.ProjectLimits[projectId]
+	projectLimits, ok := handler.AccountsMongoDBClient.GetProjectLimits(projectId)
 	if !ok {
 		log.Warnf("Project %s is not in the projects limits cache", projectId)
 	} else {

--- a/pkg/server/errorshandler/handler_sentry.go
+++ b/pkg/server/errorshandler/handler_sentry.go
@@ -61,15 +61,15 @@ func (handler *Handler) HandleSentry(ctx *fasthttp.RequestCtx) {
 		log.Debugf("Body: %s", sentryEnvelopeBody)
 	}
 
-	projectId, ok := handler.AccountsMongoDBClient.ValidTokens[hawkToken]
+	projectId, ok := handler.AccountsMongoDBClient.GetValidToken(hawkToken)
 	if !ok {
-		log.Debugf("Token %s is not in the accounts cache", hawkToken)
+		log.Warnf("Token %s is not in the accounts cache", hawkToken)
 		sendAnswerHTTP(ctx, ResponseMessage{400, true, fmt.Sprintf("Integration token invalid: %s", hawkToken)})
 		return
 	}
 	log.Debugf("Found project with ID %s for integration token %s", projectId, hawkToken)
 
-	projectLimits, ok := handler.AccountsMongoDBClient.ProjectLimits[projectId]
+	projectLimits, ok := handler.AccountsMongoDBClient.GetProjectLimits(projectId)
 	if !ok {
 		log.Warnf("Project %s is not in the projects limits cache", projectId)
 	} else {

--- a/pkg/server/releasehandler/handler.go
+++ b/pkg/server/releasehandler/handler.go
@@ -33,14 +33,14 @@ func (handler *Handler) process(form *multipart.Form, token string) ResponseMess
 	}
 	_, commits := getSingleFormValue(form, "commits")
 
-	projectId, ok := handler.AccountsMongoDBClient.ValidTokens[token]
+	projectId, ok := handler.AccountsMongoDBClient.GetValidToken(token)
 	if !ok {
 		log.Debugf("Token %s is not in the accounts cache", token)
 		return ResponseMessage{400, true, fmt.Sprintf("Integration token invalid: %s", token)}
 	}
 	log.Debugf("Found project with ID %s for integration token %s", projectId, token)
 
-	projectLimits, ok := handler.AccountsMongoDBClient.ProjectLimits[projectId]
+	projectLimits, ok := handler.AccountsMongoDBClient.GetProjectLimits(projectId)
 	if !ok {
 		log.Warnf("Project %s is not in the projects limits cache", projectId)
 	} else {


### PR DESCRIPTION
should fix the following panic:

```
fatal error: concurrent map read and map write

goroutine 29999 [running]:
runtime.throw(0xd9f603, 0x21)
        /usr/local/go/src/runtime/panic.go:1117 +0x72 fp=0xc00022fae0 sp=0xc00022fab0 pc=0x436fd2
runtime.mapaccess2_faststr(0xc97420, 0xc000824150, 0xc000182c18, 0x18, 0xc00022fce0, 0x2)
        /usr/local/go/src/runtime/map_faststr.go:116 +0x4a5 fp=0xc00022fb50 sp=0xc00022fae0 pc=0x4141e5
github.com/codex-team/hawk.collector/pkg/server/errorshandler.(*Handler).process(0xc0003425d8, 0xc00016e700, 0x54f, 0x700, 0xc00022fe80, 0x1, 0x1, 0x0)
        /build/pkg/server/errorshandler/handler.go:68 +0x306 fp=0xc00022fdd0 sp=0xc00022fb50 pc=0xbd04a6
github.com/codex-team/hawk.collector/pkg/server/errorshandler.(*Handler).HandleWebsocket.func1(0xc000756f20)
        /build/pkg/server/errorshandler/handler_websocket.go:90 +0x1e5 fp=0xc00022fec0 sp=0xc00022fdd0 pc=0xbd37a5
github.com/fasthttp/websocket.(*FastHTTPUpgrader).Upgrade.func1(0xf23388, 0xc00057a1e0)
        /go/pkg/mod/github.com/fasthttp/websocket@v1.4.3/server_fasthttp.go:201 +0x1be fp=0xc00022ff68 sp=0xc00022fec0 pc=0xbcec1e
github.com/valyala/fasthttp.hijackConnHandler(0xf0eee0, 0xc000796b40, 0xf23540, 0xc0000b0438, 0xc0003426c0, 0xc00085bb00)
        /go/pkg/mod/github.com/valyala/fasthttp@v1.25.0/server.go:2365 +0x7b fp=0xc00022ffb0 sp=0xc00022ff68 pc=0xb9e35b
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1371 +0x1 fp=0xc00022ffb8 sp=0xc00022ffb0 pc=0x46cac1
created by github.com/valyala/fasthttp.(*Server).serveConn
        /go/pkg/mod/github.com/valyala/fasthttp@v1.25.0/server.go:2320 +0xbd8
```