### PR TITLE
imp(collector): move timestamp to event level

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/pkg/server/errorshandler/handler.go
+++ b/pkg/server/errorshandler/handler.go
@@ -92,7 +92,7 @@ func (handler *Handler) process(body []byte) ResponseMessage {
 	}
 
 	// convert message to JSON format
-	messageToSend := BrokerMessage{ProjectId: projectId, Payload: []byte(stringPayload), CatcherType: message.CatcherType, timestamp: time.Now().Unix()}
+	messageToSend := BrokerMessage{ProjectId: projectId, Payload: []byte(stringPayload), CatcherType: message.CatcherType, Timestamp: time.Now().Unix()}
 	rawMessage, err := json.Marshal(messageToSend)
 	if err != nil {
 		log.Errorf("Message marshalling error: %v", err)

--- a/pkg/server/errorshandler/handler.go
+++ b/pkg/server/errorshandler/handler.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
-	"github.com/tidwall/sjson"
 )
 
 const DefaultQueueName = "errors/default"
@@ -92,8 +91,10 @@ func (handler *Handler) process(body []byte) ResponseMessage {
 		return ResponseMessage{400, true, "Invalid payload JSON format"}
 	}
 
+	stringMessage := string(message)
+
 	// convert message to JSON format
-	messageToSend := BrokerMessage{ProjectId: projectId, Payload: []byte(modifiedMessage), CatcherType: message.CatcherType, timestamp: time.Now().Unix()}
+	messageToSend := BrokerMessage{ProjectId: projectId, Payload: []byte(stringMessage), CatcherType: message.CatcherType, timestamp: time.Now().Unix()}
 	rawMessage, err := json.Marshal(messageToSend)
 	if err != nil {
 		log.Errorf("Message marshalling error: %v", err)

--- a/pkg/server/errorshandler/handler.go
+++ b/pkg/server/errorshandler/handler.go
@@ -91,10 +91,8 @@ func (handler *Handler) process(body []byte) ResponseMessage {
 		return ResponseMessage{400, true, "Invalid payload JSON format"}
 	}
 
-	stringMessage := string(message)
-
 	// convert message to JSON format
-	messageToSend := BrokerMessage{ProjectId: projectId, Payload: []byte(stringMessage), CatcherType: message.CatcherType, timestamp: time.Now().Unix()}
+	messageToSend := BrokerMessage{ProjectId: projectId, Payload: []byte(stringPayload), CatcherType: message.CatcherType, timestamp: time.Now().Unix()}
 	rawMessage, err := json.Marshal(messageToSend)
 	if err != nil {
 		log.Errorf("Message marshalling error: %v", err)

--- a/pkg/server/errorshandler/handler.go
+++ b/pkg/server/errorshandler/handler.go
@@ -87,18 +87,13 @@ func (handler *Handler) process(body []byte) ResponseMessage {
 	}
 
 	// Validate if message is a valid JSON
-	stringMessage := string(message.Payload)
-	if !gjson.Valid(stringMessage) {
+	stringPayload := string(message.Payload)
+	if !gjson.Valid(stringPayload) {
 		return ResponseMessage{400, true, "Invalid payload JSON format"}
 	}
 
-	modifiedMessage, err := sjson.Set(stringMessage, "timestamp", time.Now().Unix())
-	if err != nil {
-		return ResponseMessage{400, true, fmt.Sprintf("%s", err)}
-	}
-
 	// convert message to JSON format
-	messageToSend := BrokerMessage{ProjectId: projectId, Payload: []byte(modifiedMessage), CatcherType: message.CatcherType}
+	messageToSend := BrokerMessage{ProjectId: projectId, Payload: []byte(modifiedMessage), CatcherType: message.CatcherType, timestamp: time.Now().Unix()}
 	rawMessage, err := json.Marshal(messageToSend)
 	if err != nil {
 		log.Errorf("Message marshalling error: %v", err)

--- a/pkg/server/errorshandler/handler.go
+++ b/pkg/server/errorshandler/handler.go
@@ -92,7 +92,7 @@ func (handler *Handler) process(body []byte) ResponseMessage {
 	}
 
 	// convert message to JSON format
-	messageToSend := BrokerMessage{ProjectId: projectId, Payload: []byte(stringPayload), CatcherType: message.CatcherType, Timestamp: time.Now().Unix()}
+	messageToSend := BrokerMessage{Timestamp: time.Now().Unix(), ProjectId: projectId, Payload: []byte(stringPayload), CatcherType: message.CatcherType}
 	rawMessage, err := json.Marshal(messageToSend)
 	if err != nil {
 		log.Errorf("Message marshalling error: %v", err)

--- a/pkg/server/errorshandler/handler_sentry.go
+++ b/pkg/server/errorshandler/handler_sentry.go
@@ -3,6 +3,7 @@ package errorshandler
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/codex-team/hawk.collector/pkg/broker"
 	log "github.com/sirupsen/logrus"

--- a/pkg/server/errorshandler/handler_sentry.go
+++ b/pkg/server/errorshandler/handler_sentry.go
@@ -102,7 +102,7 @@ func (handler *Handler) HandleSentry(ctx *fasthttp.RequestCtx) {
 		sendAnswerHTTP(ctx, ResponseMessage{400, true, "Cannot serialize envelope"})
 	}
 
-	messageToSend := BrokerMessage{ProjectId: projectId, Payload: json.RawMessage(jsonMessage), CatcherType: CatcherType}
+	messageToSend := BrokerMessage{ProjectId: projectId, Payload: json.RawMessage(jsonMessage), CatcherType: CatcherType, timestamp: time.Now().Unix()}
 	payloadToSend, err := json.Marshal(messageToSend)
 	if err != nil {
 		log.Errorf("Message marshalling error: %v", err)

--- a/pkg/server/errorshandler/handler_sentry.go
+++ b/pkg/server/errorshandler/handler_sentry.go
@@ -103,7 +103,7 @@ func (handler *Handler) HandleSentry(ctx *fasthttp.RequestCtx) {
 		sendAnswerHTTP(ctx, ResponseMessage{400, true, "Cannot serialize envelope"})
 	}
 
-	messageToSend := BrokerMessage{ProjectId: projectId, Payload: json.RawMessage(jsonMessage), CatcherType: CatcherType, Timestamp: time.Now().Unix()}
+	messageToSend := BrokerMessage{Timestamp: time.Now().Unix(), ProjectId: projectId, Payload: json.RawMessage(jsonMessage), CatcherType: CatcherType}
 	payloadToSend, err := json.Marshal(messageToSend)
 	if err != nil {
 		log.Errorf("Message marshalling error: %v", err)

--- a/pkg/server/errorshandler/handler_sentry.go
+++ b/pkg/server/errorshandler/handler_sentry.go
@@ -103,7 +103,7 @@ func (handler *Handler) HandleSentry(ctx *fasthttp.RequestCtx) {
 		sendAnswerHTTP(ctx, ResponseMessage{400, true, "Cannot serialize envelope"})
 	}
 
-	messageToSend := BrokerMessage{ProjectId: projectId, Payload: json.RawMessage(jsonMessage), CatcherType: CatcherType, timestamp: time.Now().Unix()}
+	messageToSend := BrokerMessage{ProjectId: projectId, Payload: json.RawMessage(jsonMessage), CatcherType: CatcherType, Timestamp: time.Now().Unix()}
 	payloadToSend, err := json.Marshal(messageToSend)
 	if err != nil {
 		log.Errorf("Message marshalling error: %v", err)

--- a/pkg/server/errorshandler/messages.go
+++ b/pkg/server/errorshandler/messages.go
@@ -23,6 +23,7 @@ type BrokerMessage struct {
 	ProjectId   string          `json:"projectId"`
 	Payload     json.RawMessage `json:"payload"`
 	CatcherType string          `json:"catcherType"`
+	timestamp int64             `json:"timestamp"`
 }
 
 type RawSentryMessage struct {

--- a/pkg/server/errorshandler/messages.go
+++ b/pkg/server/errorshandler/messages.go
@@ -23,7 +23,7 @@ type BrokerMessage struct {
 	ProjectId   string          `json:"projectId"`
 	Payload     json.RawMessage `json:"payload"`
 	CatcherType string          `json:"catcherType"`
-	timestamp int64             `json:"timestamp"`
+	Timestamp int64             `json:"timestamp"`
 }
 
 type RawSentryMessage struct {


### PR DESCRIPTION
## Problem
- Now collector adds timestamp to the `event.payload`, but repetitions have timestamp at `event` level

## Solution
- Add timestamp exactly to the event

> [!Note]
> This is part of the work on moving timestamp out of payload check other prs:
> garage api workers types