### PR TITLE
chore(): add new time-series key

### DIFF
--- a/pkg/server/errorshandler/handler.go
+++ b/pkg/server/errorshandler/handler.go
@@ -134,6 +134,10 @@ func GetQueueCache(nonDefaultQueues []string) map[string]bool {
 
 // getTimeSeriesKey generates a Redis TimeSeries key for project metrics
 func getTimeSeriesKey(projectId, metricType, granularity string) string {
+	if metricType == "events-rate-limited" {
+		return fmt.Sprintf("ts:project-%s:%s:%s", metricType, projectId, granularity)
+	}
+
 	return fmt.Sprintf("ts:collector-project-%s:%s:%s", metricType, projectId, granularity)
 }
 

--- a/pkg/server/errorshandler/handler.go
+++ b/pkg/server/errorshandler/handler.go
@@ -73,7 +73,7 @@ func (handler *Handler) process(body []byte) ResponseMessage {
 
 	if handler.RedisClient.IsBlocked(projectId) {
 		handler.ErrorsBlockedByLimit.Inc()
-		handler.recordProjectMetrics(projectId, "events-rate-limited")
+		handler.recordProjectMetrics(projectId, "events-rate-limited", false)
 		return ResponseMessage{402, true, "Project has exceeded the events limit"}
 	}
 
@@ -83,7 +83,7 @@ func (handler *Handler) process(body []byte) ResponseMessage {
 		return ResponseMessage{402, true, "Failed to update rate limit"}
 	}
 	if !rateWithinLimit {
-		handler.recordProjectMetrics(projectId, "events-rate-limited")
+		handler.recordProjectMetrics(projectId, "events-rate-limited", false)
 		return ResponseMessage{402, true, "Rate limit exceeded"}
 	}
 
@@ -110,7 +110,7 @@ func (handler *Handler) process(body []byte) ResponseMessage {
 	handler.ErrorsProcessed.Inc()
 
 	// record project metrics
-	handler.recordProjectMetrics(projectId, "events-accepted")
+	handler.recordProjectMetrics(projectId, "events-accepted", true)
 
 	return ResponseMessage{200, false, "OK"}
 }
@@ -133,20 +133,23 @@ func GetQueueCache(nonDefaultQueues []string) map[string]bool {
 }
 
 // getTimeSeriesKey generates a Redis TimeSeries key for project metrics
-func getTimeSeriesKey(projectId, metricType, granularity string) string {
-	if metricType == "events-rate-limited" {
-		return fmt.Sprintf("ts:project-%s:%s:%s", metricType, projectId, granularity)
+func getTimeSeriesKey(projectId, metricType, granularity string, isSystemMetric bool) string {
+	// flag determines which counter would be incremented
+	if isSystemMetric {
+		// ts:collector-project-%s:%s:%s could be used in admin
+		return fmt.Sprintf("ts:collector-project-%s:%s:%s", metricType, projectId, granularity)
 	}
 
-	return fmt.Sprintf("ts:collector-project-%s:%s:%s", metricType, projectId, granularity)
+	// ts:project-%s:%s:%s is used in api for chart retrieving
+	return fmt.Sprintf("ts:project-%s:%s:%s", metricType, projectId, granularity)
 }
 
 // recordProjectMetrics records project metrics to Redis TimeSeries
 // metricType can be: "events-accepted", "events-rate-limited", etc.
-func (handler *Handler) recordProjectMetrics(projectId, metricType string) {
-	minutelyKey := getTimeSeriesKey(projectId, metricType, "minutely")
-	hourlyKey := getTimeSeriesKey(projectId, metricType, "hourly")
-	dailyKey := getTimeSeriesKey(projectId, metricType, "daily")
+func (handler *Handler) recordProjectMetrics(projectId, metricType string, isSystemMetric bool) {
+	minutelyKey := getTimeSeriesKey(projectId, metricType, "minutely", isSystemMetric)
+	hourlyKey := getTimeSeriesKey(projectId, metricType, "hourly", isSystemMetric)
+	dailyKey := getTimeSeriesKey(projectId, metricType, "daily", isSystemMetric)
 
 	labels := map[string]string{
 		"type":    "error",

--- a/pkg/server/errorshandler/handler.go
+++ b/pkg/server/errorshandler/handler.go
@@ -134,7 +134,7 @@ func GetQueueCache(nonDefaultQueues []string) map[string]bool {
 
 // getTimeSeriesKey generates a Redis TimeSeries key for project metrics
 func getTimeSeriesKey(projectId, metricType, granularity string) string {
-	return fmt.Sprintf("ts:project-%s:%s:%s", metricType, projectId, granularity)
+	return fmt.Sprintf("ts:collector-project-%s:%s:%s", metricType, projectId, granularity)
 }
 
 // recordProjectMetrics records project metrics to Redis TimeSeries

--- a/pkg/server/errorshandler/handler_sentry.go
+++ b/pkg/server/errorshandler/handler_sentry.go
@@ -102,7 +102,7 @@ func (handler *Handler) HandleSentry(ctx *fasthttp.RequestCtx) {
 
 	if handler.RedisClient.IsBlocked(projectId) {
 		handler.ErrorsBlockedByLimit.Inc()
-		handler.recordProjectMetrics(projectId, "events-rate-limited")
+		handler.recordProjectMetrics(projectId, "events-rate-limited", false)
 		sendAnswerHTTP(ctx, ResponseMessage{402, true, "Project has exceeded the events limit"})
 		return
 	}
@@ -115,7 +115,7 @@ func (handler *Handler) HandleSentry(ctx *fasthttp.RequestCtx) {
 	}
 
 	if !rateWithinLimit {
-		handler.recordProjectMetrics(projectId, "events-rate-limited")
+		handler.recordProjectMetrics(projectId, "events-rate-limited", false)
 		sendAnswerHTTP(ctx, ResponseMessage{402, true, "Rate limit exceeded"})
 		return
 	}
@@ -144,7 +144,7 @@ func (handler *Handler) HandleSentry(ctx *fasthttp.RequestCtx) {
 	handler.ErrorsProcessed.Inc()
 
 	// record project metrics
-	handler.recordProjectMetrics(projectId, "events-accepted")
+	handler.recordProjectMetrics(projectId, "events-accepted", true)
 
 	sendAnswerHTTP(ctx, ResponseMessage{200, false, "OK"})
 }

--- a/pkg/server/errorshandler/test_helpers.go
+++ b/pkg/server/errorshandler/test_helpers.go
@@ -12,9 +12,9 @@ import (
 // Usage: handler.GenerateTestTimeSeriesData(projectId)
 func (handler *Handler) GenerateTestTimeSeriesData(projectId string) error {
 	metricType := "events-accepted"
-	minutelyKey := getTimeSeriesKey(projectId, metricType, "minutely")
-	hourlyKey := getTimeSeriesKey(projectId, metricType, "hourly")
-	dailyKey := getTimeSeriesKey(projectId, metricType, "daily")
+	minutelyKey := getTimeSeriesKey(projectId, metricType, "minutely", true)
+	hourlyKey := getTimeSeriesKey(projectId, metricType, "hourly", true)
+	dailyKey := getTimeSeriesKey(projectId, metricType, "daily", true)
 
 	// Delete existing keys to avoid accumulation
 	log.Infof("Deleting existing test data keys for project %s...", projectId)


### PR DESCRIPTION
## Problem
Collector should not increment time series key because some events are discarded on sentry worker level, that leads to incorrect chart data

## Solution
Collector now increments own counter (for admin purposes)

This counter would not be used in api of the app, current counter would be moved to grouper, so we would see actual data on chart