### PR TITLE
feat(): sentry format parsing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,10 +5,19 @@ on: [push, pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: GolangCI Lint
-        uses: golangci/golangci-lint-action@v2
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          version: latest
+          go-version: '1.21'
+          cache: true
+
+      - name: GolangCI Lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.63.4
+          args: --verbose

--- a/pkg/sentry/converter.go
+++ b/pkg/sentry/converter.go
@@ -276,7 +276,7 @@ func IsJsSDK(eventPayload gjson.Result) bool {
 
 // TransformToHawkFormat converts a Sentry event item into a Hawk broker message.
 func TransformToHawkFormat(envelopeHeaders json.RawMessage, item EnvelopeItem, projectID string) (*HawkBrokerPayload, error) {
-	if item.Payload == nil || len(item.Payload) == 0 || string(item.Payload) == "null" {
+	if len(item.Payload) == 0 || string(item.Payload) == "null" {
 		return nil, fmt.Errorf("Item payload is missing")
 	}
 

--- a/pkg/sentry/converter.go
+++ b/pkg/sentry/converter.go
@@ -280,6 +280,11 @@ func TransformToHawkFormat(envelopeHeaders json.RawMessage, item EnvelopeItem, p
 		return nil, fmt.Errorf("Item payload is missing")
 	}
 
+	// Validate the payload, it should be Valid JSON
+	if !gjson.ValidBytes(item.Payload) {
+		return nil, fmt.Errorf("Invalid event payload JSON")
+	}
+
 	headers := gjson.ParseBytes(envelopeHeaders)
 	eventPayload := gjson.ParseBytes(item.Payload)
 

--- a/pkg/sentry/converter.go
+++ b/pkg/sentry/converter.go
@@ -1,0 +1,453 @@
+package sentry
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+// CatcherVersion matches hawk-worker-sentry package.json version (parity).
+const CatcherVersion = "1.0.1"
+
+// Queue / catcher type constants matching Node worker routing.
+const (
+	CatcherTypeJavaScript = "errors/javascript"
+	CatcherTypeDefault    = "errors/default"
+)
+
+// sentryJsSDK list from Node worker (including capacirtor typo — do not "fix").
+var sentryJsSDK = []string{"browser", "react", "vue", "angular", "capacirtor", "electron"}
+
+// addonFields are Sentry event fields copied into addons.sentry (same order as Node).
+var addonFields = []string{
+	"message",
+	"logentry",
+	"timestamp",
+	"start_timestamp",
+	"level",
+	"platform",
+	"server_name",
+	"dist",
+	"environment",
+	"request",
+	"transaction",
+	"modules",
+	"fingerprint",
+	"tags",
+	"extra",
+}
+
+// SourceCodeLine is a single line of inline source context.
+type SourceCodeLine struct {
+	Line    int    `json:"line"`
+	Content string `json:"content"`
+}
+
+// BacktraceFrame is a Hawk backtrace frame.
+type BacktraceFrame struct {
+	File       string           `json:"file"`
+	Line       int              `json:"line"`
+	Column     *int             `json:"column,omitempty"`
+	Function   string           `json:"function,omitempty"`
+	Arguments  []string         `json:"arguments,omitempty"`
+	SourceCode []SourceCodeLine `json:"sourceCode,omitempty"`
+}
+
+// HawkUser is a Hawk user object.
+type HawkUser struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
+	URL  string `json:"url,omitempty"`
+}
+
+// HawkEventPayload is the Hawk catcher payload produced from a Sentry event.
+type HawkEventPayload struct {
+	Title          string                 `json:"title"`
+	Type           string                 `json:"type"`
+	CatcherVersion string                 `json:"catcherVersion"`
+	Backtrace      []BacktraceFrame       `json:"backtrace,omitempty"`
+	Context        json.RawMessage        `json:"context,omitempty"`
+	User           *HawkUser              `json:"user,omitempty"`
+	Release        string                 `json:"release,omitempty"`
+	Addons         map[string]interface{} `json:"addons,omitempty"`
+}
+
+// HawkBrokerPayload is the message body published to errors/* queues.
+type HawkBrokerPayload struct {
+	ProjectID   string           `json:"projectId"`
+	CatcherType string           `json:"catcherType"`
+	Timestamp   int64            `json:"timestamp"`
+	Payload     HawkEventPayload `json:"payload"`
+}
+
+// ComposeTitle builds Hawk title from a Sentry event payload.
+func ComposeTitle(eventPayload gjson.Result) string {
+	exception := eventPayload.Get("exception.values.0")
+	if exception.Exists() {
+		excType := exception.Get("type").String()
+		if excType == "" {
+			excType = "Unknown"
+		}
+		return fmt.Sprintf("%s: %s", excType, exception.Get("value").String())
+	}
+
+	message := eventPayload.Get("message")
+	if message.Exists() && message.Type != gjson.Null {
+		return message.String()
+	}
+
+	return "Unknown: "
+}
+
+// ComposeBacktrace builds Hawk backtrace from the first exception's stacktrace.
+func ComposeBacktrace(eventPayload gjson.Result) []BacktraceFrame {
+	frames := eventPayload.Get("exception.values.0.stacktrace.frames")
+	if !frames.Exists() || !frames.IsArray() {
+		return nil
+	}
+
+	rawFrames := frames.Array()
+	if len(rawFrames) == 0 {
+		return nil
+	}
+
+	// Sentry sends backtrace in reverse order — reverse to get correct order
+	reversed := make([]gjson.Result, len(rawFrames))
+	for i, frame := range rawFrames {
+		reversed[len(rawFrames)-1-i] = frame
+	}
+
+	backtrace := make([]BacktraceFrame, 0, len(reversed))
+	for _, frame := range reversed {
+		file := firstNonEmpty(
+			frame.Get("filename").String(),
+			frame.Get("abs_path").String(),
+			frame.Get("module").String(),
+			frame.Get("instruction_addr").String(),
+			"unknown location",
+		)
+
+		line := int(frame.Get("lineno").Int())
+		bt := BacktraceFrame{
+			File: file,
+			Line: line,
+		}
+
+		hasContextLine := frame.Get("context_line").Exists() && frame.Get("context_line").Type != gjson.Null
+		hasPreContext := frame.Get("pre_context").Exists() && frame.Get("pre_context").IsArray()
+		hasPostContext := frame.Get("post_context").Exists() && frame.Get("post_context").IsArray()
+		isSomeLinesAvailable := hasContextLine || hasPreContext || hasPostContext
+
+		if isSomeLinesAvailable && frame.Get("lineno").Exists() {
+			sourceCode := make([]SourceCodeLine, 0)
+			lineNo := int(frame.Get("lineno").Int())
+
+			if hasPreContext {
+				pre := frame.Get("pre_context").Array()
+				for index, lineContent := range pre {
+					sourceCode = append(sourceCode, SourceCodeLine{
+						Line:    lineNo + index - len(pre),
+						Content: lineContent.String(),
+					})
+				}
+			}
+
+			if hasContextLine {
+				sourceCode = append(sourceCode, SourceCodeLine{
+					Line:    lineNo,
+					Content: frame.Get("context_line").String(),
+				})
+			}
+
+			if hasPostContext {
+				for index, lineContent := range frame.Get("post_context").Array() {
+					sourceCode = append(sourceCode, SourceCodeLine{
+						Line:    lineNo + index + 1,
+						Content: lineContent.String(),
+					})
+				}
+			}
+
+			bt.SourceCode = sourceCode
+		}
+
+		if frame.Get("colno").Exists() && frame.Get("colno").Type != gjson.Null {
+			col := int(frame.Get("colno").Int())
+			bt.Column = &col
+		}
+
+		if fn := frame.Get("function"); fn.Exists() && fn.Type != gjson.Null && fn.String() != "" {
+			bt.Function = fn.String()
+		}
+
+		if vars := frame.Get("vars"); vars.Exists() && vars.IsObject() {
+			args := make([]string, 0)
+			vars.ForEach(func(key, value gjson.Result) bool {
+				args = append(args, flattenObject(value, key.String())...)
+				return true
+			})
+			if len(args) > 0 {
+				bt.Arguments = args
+			}
+		}
+
+		backtrace = append(backtrace, bt)
+	}
+
+	if len(backtrace) == 0 {
+		return nil
+	}
+	return backtrace
+}
+
+// ComposeContext returns Sentry contexts as raw JSON, or nil if absent.
+func ComposeContext(eventPayload gjson.Result) json.RawMessage {
+	contexts := eventPayload.Get("contexts")
+	if !contexts.Exists() || contexts.Type == gjson.Null {
+		return nil
+	}
+	return json.RawMessage(contexts.Raw)
+}
+
+// ComposeAddons copies selected Sentry fields into addons (same field list as Node).
+func ComposeAddons(eventPayload gjson.Result) map[string]interface{} {
+	addons := make(map[string]interface{})
+	for _, field := range addonFields {
+		value := eventPayload.Get(field)
+		if !value.Exists() || value.Type == gjson.Null {
+			continue
+		}
+		var decoded interface{}
+		if err := json.Unmarshal([]byte(value.Raw), &decoded); err != nil {
+			continue
+		}
+		addons[field] = decoded
+	}
+	if len(addons) == 0 {
+		return nil
+	}
+	return addons
+}
+
+// ComposeUserData maps Sentry user to Hawk user.
+func ComposeUserData(eventPayload gjson.Result) *HawkUser {
+	user := eventPayload.Get("user")
+	if !user.Exists() || user.Type == gjson.Null {
+		return nil
+	}
+
+	id := "unknown"
+	if user.Get("id").Exists() && user.Get("id").Type != gjson.Null {
+		id = user.Get("id").String()
+	}
+
+	u := &HawkUser{ID: id}
+	if username := user.Get("username"); username.Exists() && username.Type != gjson.Null {
+		u.Name = username.String()
+	}
+	if email := user.Get("email"); email.Exists() && email.Type != gjson.Null {
+		u.URL = email.String()
+	}
+	return u
+}
+
+// IsJsSDK reports whether the Sentry SDK name is a JavaScript-related SDK.
+func IsJsSDK(eventPayload gjson.Result) bool {
+	sdkName := eventPayload.Get("sdk.name")
+	if !sdkName.Exists() || sdkName.Type == gjson.Null {
+		return false
+	}
+	name := sdkName.String()
+	if name == "" {
+		return false
+	}
+
+	for _, jsSDK := range sentryJsSDK {
+		if name == jsSDK || strings.Contains(name, jsSDK) {
+			return true
+		}
+	}
+	return false
+}
+
+// TransformToHawkFormat converts a Sentry event item into a Hawk broker message.
+func TransformToHawkFormat(envelopeHeaders json.RawMessage, item EnvelopeItem, projectID string) (*HawkBrokerPayload, error) {
+	if item.Payload == nil || len(item.Payload) == 0 || string(item.Payload) == "null" {
+		return nil, fmt.Errorf("Item payload is missing")
+	}
+
+	headers := gjson.ParseBytes(envelopeHeaders)
+	eventPayload := gjson.ParseBytes(item.Payload)
+
+	sentAt := headers.Get("sent_at").String()
+	sentAtUnix, err := parseSentAtUnix(sentAt)
+	if err != nil {
+		return nil, err
+	}
+
+	isJs := IsJsSDK(eventPayload)
+	catcherType := CatcherTypeDefault
+	if isJs {
+		catcherType = CatcherTypeJavaScript
+	}
+
+	title := ComposeTitle(eventPayload)
+	level := eventPayload.Get("level").String()
+	if level == "" {
+		level = "error"
+	}
+
+	event := HawkEventPayload{
+		Title:          title,
+		Type:           level,
+		CatcherVersion: CatcherVersion,
+	}
+
+	if bt := ComposeBacktrace(eventPayload); bt != nil {
+		event.Backtrace = bt
+	}
+	if ctx := ComposeContext(eventPayload); ctx != nil {
+		event.Context = ctx
+	}
+	if user := ComposeUserData(eventPayload); user != nil {
+		event.User = user
+	}
+	if addons := ComposeAddons(eventPayload); addons != nil {
+		event.Addons = map[string]interface{}{
+			"sentry": addons,
+		}
+	}
+
+	release := eventPayload.Get("release").String()
+	if release == "" {
+		release = headers.Get("trace.release").String()
+	}
+	if release != "" {
+		event.Release = release
+	}
+
+	return &HawkBrokerPayload{
+		ProjectID:   projectID,
+		CatcherType: catcherType,
+		Timestamp:   sentAtUnix,
+		Payload:     event,
+	}, nil
+}
+
+func parseSentAtUnix(sentAt string) (int64, error) {
+	if sentAt == "" {
+		return 0, fmt.Errorf("Invalid sent_at timestamp: %s", sentAt)
+	}
+	t, err := time.Parse(time.RFC3339Nano, sentAt)
+	if err != nil {
+		t, err = time.Parse(time.RFC3339, sentAt)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("Invalid sent_at timestamp: %s", sentAt)
+	}
+	return t.Unix(), nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// flattenObject ports Node flattenObject — preserves key order via gjson.ForEach.
+func flattenObject(obj gjson.Result, prefix string) []string {
+	if obj.Type == gjson.Null {
+		if prefix != "" {
+			return []string{prefix + "=null"}
+		}
+		return []string{"null"}
+	}
+
+	if !obj.Exists() {
+		if prefix != "" {
+			return []string{prefix + "=undefined"}
+		}
+		return []string{"undefined"}
+	}
+
+	switch obj.Type {
+	case gjson.JSON:
+		if obj.IsArray() {
+			arr := obj.Array()
+			if len(arr) == 0 {
+				if prefix != "" {
+					return []string{prefix + "=[]"}
+				}
+				return []string{"[]"}
+			}
+			result := make([]string, 0)
+			for index, value := range arr {
+				key := strconv.Itoa(index)
+				if prefix != "" {
+					key = prefix + "." + key
+				}
+				result = append(result, flattenObject(value, key)...)
+			}
+			return result
+		}
+		if obj.IsObject() {
+			entries := make([]gjson.Result, 0)
+			keys := make([]string, 0)
+			obj.ForEach(func(key, value gjson.Result) bool {
+				keys = append(keys, key.String())
+				entries = append(entries, value)
+				return true
+			})
+			if len(keys) == 0 {
+				if prefix != "" {
+					return []string{prefix + "={}"}
+				}
+				return []string{"{}"}
+			}
+			result := make([]string, 0)
+			for i, key := range keys {
+				newPrefix := key
+				if prefix != "" {
+					newPrefix = prefix + "." + key
+				}
+				result = append(result, flattenObject(entries[i], newPrefix)...)
+			}
+			return result
+		}
+	}
+
+	// Primitive
+	val := formatPrimitive(obj)
+	if prefix != "" {
+		return []string{prefix + "=" + val}
+	}
+	return []string{val}
+}
+
+func formatPrimitive(obj gjson.Result) string {
+	switch obj.Type {
+	case gjson.True:
+		return "true"
+	case gjson.False:
+		return "false"
+	case gjson.Number:
+		// Match JS number stringification for integers
+		if obj.Num == float64(int64(obj.Num)) {
+			return strconv.FormatInt(int64(obj.Num), 10)
+		}
+		return strconv.FormatFloat(obj.Num, 'f', -1, 64)
+	case gjson.String:
+		return obj.String()
+	case gjson.Null:
+		return "null"
+	default:
+		return obj.Raw
+	}
+}

--- a/pkg/sentry/converter.go
+++ b/pkg/sentry/converter.go
@@ -13,10 +13,10 @@ import (
 // CatcherVersion matches hawk-worker-sentry package.json version (parity).
 const CatcherVersion = "1.0.1"
 
-// Queue / catcher type constants matching Node worker routing.
+// Worker / queue names used to route transformed events.
 const (
-	CatcherTypeJavaScript = "errors/javascript"
-	CatcherTypeDefault    = "errors/default"
+	WorkerTypeJavaScript = "errors/javascript"
+	WorkerTypeDefault    = "errors/default"
 )
 
 // sentryJsSDK list from Node worker (including capacirtor typo — do not "fix").
@@ -121,6 +121,13 @@ func ComposeBacktrace(eventPayload gjson.Result) []BacktraceFrame {
 		reversed[len(rawFrames)-1-i] = frame
 	}
 
+	// Cap frames to limit memory: some SDKs send 250+ frames (several MB).
+	// After reverse, index 0 is the newest (crash) frame.
+	const maxBacktraceFrames = 20
+	if len(reversed) > maxBacktraceFrames {
+		reversed = reversed[:maxBacktraceFrames]
+	}
+
 	backtrace := make([]BacktraceFrame, 0, len(reversed))
 	for _, frame := range reversed {
 		file := firstNonEmpty(
@@ -148,9 +155,10 @@ func ComposeBacktrace(eventPayload gjson.Result) []BacktraceFrame {
 
 			if hasPreContext {
 				pre := frame.Get("pre_context").Array()
+				preLen := len(pre)
 				for index, lineContent := range pre {
 					sourceCode = append(sourceCode, SourceCodeLine{
-						Line:    lineNo + index - len(pre),
+						Line:    lineNo + index - preLen,
 						Content: lineContent.String(),
 					})
 				}
@@ -275,6 +283,8 @@ func IsJsSDK(eventPayload gjson.Result) bool {
 }
 
 // TransformToHawkFormat converts a Sentry event item into a Hawk broker message.
+// Item payloads may arrive as newline-delimited JSON or as length-prefixed bytes
+// (when the item header includes "length"); both are raw JSON bytes by this point.
 func TransformToHawkFormat(envelopeHeaders json.RawMessage, item EnvelopeItem, projectID string) (*HawkBrokerPayload, error) {
 	if len(item.Payload) == 0 || string(item.Payload) == "null" {
 		return nil, fmt.Errorf("Item payload is missing")
@@ -295,9 +305,9 @@ func TransformToHawkFormat(envelopeHeaders json.RawMessage, item EnvelopeItem, p
 	}
 
 	isJs := IsJsSDK(eventPayload)
-	catcherType := CatcherTypeDefault
+	workerType := WorkerTypeDefault
 	if isJs {
-		catcherType = CatcherTypeJavaScript
+		workerType = WorkerTypeJavaScript
 	}
 
 	title := ComposeTitle(eventPayload)
@@ -337,7 +347,7 @@ func TransformToHawkFormat(envelopeHeaders json.RawMessage, item EnvelopeItem, p
 
 	return &HawkBrokerPayload{
 		ProjectID:   projectID,
-		CatcherType: catcherType,
+		CatcherType: workerType,
 		Timestamp:   sentAtUnix,
 		Payload:     event,
 	}, nil
@@ -366,7 +376,9 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-// flattenObject ports Node flattenObject — preserves key order via gjson.ForEach.
+// flattenObject turns nested JSON (objects/arrays/primitives) into flat "key=value"
+// strings used as Hawk backtrace frame arguments. Nested keys are joined with dots
+// (e.g. {"a":{"b":1}} → "a.b=1"). Key order follows the original JSON object order.
 func flattenObject(obj gjson.Result, prefix string) []string {
 	if obj.Type == gjson.Null {
 		if prefix != "" {

--- a/pkg/sentry/converter_test.go
+++ b/pkg/sentry/converter_test.go
@@ -1,6 +1,8 @@
 package sentry
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -113,6 +115,22 @@ func TestComposeBacktrace(t *testing.T) {
 		assert.Equal(t, 123, bt[0].Line)
 		assert.Equal(t, "test1.js", bt[1].File)
 		assert.Equal(t, 10, bt[1].Line)
+	})
+
+	t.Run("trims to 20 newest frames", func(t *testing.T) {
+		frames := make([]string, 0, 25)
+		for i := 0; i < 25; i++ {
+			frames = append(frames, fmt.Sprintf(`{"filename":"f%d.js","lineno":%d}`, i, i))
+		}
+		event := gjson.Parse(fmt.Sprintf(
+			`{"exception":{"values":[{"stacktrace":{"frames":[%s]}}]}}`,
+			strings.Join(frames, ","),
+		))
+		bt := ComposeBacktrace(event)
+		require.Len(t, bt, 20)
+		// After reverse, newest (f24) is first; oldest kept is f5
+		assert.Equal(t, "f24.js", bt[0].File)
+		assert.Equal(t, "f5.js", bt[19].File)
 	})
 }
 

--- a/pkg/sentry/converter_test.go
+++ b/pkg/sentry/converter_test.go
@@ -1,0 +1,188 @@
+package sentry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestComposeTitle(t *testing.T) {
+	t.Run("from exception type and value", func(t *testing.T) {
+		event := gjson.Parse(`{"exception":{"values":[{"type":"Error","value":"Something went wrong"}]}}`)
+		assert.Equal(t, "Error: Something went wrong", ComposeTitle(event))
+	})
+
+	t.Run("missing exception data", func(t *testing.T) {
+		event := gjson.Parse(`{}`)
+		assert.Equal(t, "Unknown: ", ComposeTitle(event))
+	})
+
+	t.Run("from message if exception missing", func(t *testing.T) {
+		event := gjson.Parse(`{"message":"message"}`)
+		assert.Equal(t, "message", ComposeTitle(event))
+	})
+
+	t.Run("exception preferred over message", func(t *testing.T) {
+		event := gjson.Parse(`{"exception":{"values":[{"type":"Error","value":"Something went wrong"}]},"message":"message"}`)
+		assert.Equal(t, "Error: Something went wrong", ComposeTitle(event))
+	})
+}
+
+func TestComposeBacktrace(t *testing.T) {
+	t.Run("complete frame data", func(t *testing.T) {
+		event := gjson.Parse(`{
+			"exception":{"values":[{"stacktrace":{"frames":[{
+				"filename":"test.js","lineno":10,"colno":5,"function":"testFunction",
+				"vars":{"param1":"value1"},
+				"context_line":"const x = 1;",
+				"pre_context":["// comment"],
+				"post_context":["console.log(x);"]
+			}]}}]}
+		}`)
+		bt := ComposeBacktrace(event)
+		require.Len(t, bt, 1)
+		assert.Equal(t, "test.js", bt[0].File)
+		assert.Equal(t, 10, bt[0].Line)
+		require.NotNil(t, bt[0].Column)
+		assert.Equal(t, 5, *bt[0].Column)
+		assert.Equal(t, "testFunction", bt[0].Function)
+		assert.Equal(t, []string{"param1=value1"}, bt[0].Arguments)
+		assert.Equal(t, []SourceCodeLine{
+			{Line: 9, Content: "// comment"},
+			{Line: 10, Content: "const x = 1;"},
+			{Line: 11, Content: "console.log(x);"},
+		}, bt[0].SourceCode)
+	})
+
+	t.Run("missing frame data uses instruction_addr", func(t *testing.T) {
+		event := gjson.Parse(`{"exception":{"values":[{"stacktrace":{"frames":[{"instruction_addr":"0x123"}]}}]}}`)
+		bt := ComposeBacktrace(event)
+		require.Len(t, bt, 1)
+		assert.Equal(t, BacktraceFrame{File: "0x123", Line: 0}, bt[0])
+	})
+
+	t.Run("nested objects in vars", func(t *testing.T) {
+		event := gjson.Parse(`{"exception":{"values":[{"stacktrace":{"frames":[{
+			"filename":"test.js","lineno":10,
+			"vars":{"params":{"foo":1,"bar":2,"second":{"glass":3}}}
+		}]}}]}}`)
+		bt := ComposeBacktrace(event)
+		assert.Equal(t, []string{
+			"params.foo=1",
+			"params.bar=2",
+			"params.second.glass=3",
+		}, bt[0].Arguments)
+	})
+
+	t.Run("arrays in vars", func(t *testing.T) {
+		event := gjson.Parse(`{"exception":{"values":[{"stacktrace":{"frames":[{
+			"filename":"test.js","lineno":10,
+			"vars":{"items":["first","second","third"]}
+		}]}}]}}`)
+		bt := ComposeBacktrace(event)
+		assert.Equal(t, []string{"items.0=first", "items.1=second", "items.2=third"}, bt[0].Arguments)
+	})
+
+	t.Run("null values in vars", func(t *testing.T) {
+		event := gjson.Parse(`{"exception":{"values":[{"stacktrace":{"frames":[{
+			"filename":"test.js","lineno":10,
+			"vars":{"nullValue":null,"normalValue":"test"}
+		}]}}]}}`)
+		bt := ComposeBacktrace(event)
+		assert.Equal(t, []string{"nullValue=null", "normalValue=test"}, bt[0].Arguments)
+	})
+
+	t.Run("empty objects and arrays in vars", func(t *testing.T) {
+		event := gjson.Parse(`{"exception":{"values":[{"stacktrace":{"frames":[{
+			"filename":"test.js","lineno":10,
+			"vars":{"emptyObject":{},"emptyArray":[],"normalValue":"test"}
+		}]}}]}}`)
+		bt := ComposeBacktrace(event)
+		assert.Equal(t, []string{"emptyObject={}", "emptyArray=[]", "normalValue=test"}, bt[0].Arguments)
+	})
+
+	t.Run("reverses frames", func(t *testing.T) {
+		event := gjson.Parse(`{"exception":{"values":[{"stacktrace":{"frames":[
+			{"filename":"test1.js","lineno":10},
+			{"filename":"test2.js","lineno":123}
+		]}}]}}`)
+		bt := ComposeBacktrace(event)
+		assert.Equal(t, "test2.js", bt[0].File)
+		assert.Equal(t, 123, bt[0].Line)
+		assert.Equal(t, "test1.js", bt[1].File)
+		assert.Equal(t, 10, bt[1].Line)
+	})
+}
+
+func TestComposeContext(t *testing.T) {
+	t.Run("returns contexts", func(t *testing.T) {
+		event := gjson.Parse(`{"contexts":{"os":{"name":"Linux"}}}`)
+		assert.JSONEq(t, `{"os":{"name":"Linux"}}`, string(ComposeContext(event)))
+	})
+
+	t.Run("nil when missing", func(t *testing.T) {
+		assert.Nil(t, ComposeContext(gjson.Parse(`{}`)))
+	})
+}
+
+func TestComposeAddons(t *testing.T) {
+	t.Run("includes specified fields", func(t *testing.T) {
+		event := gjson.Parse(`{
+			"message":"Test message",
+			"logentry":{"message":"Test log entry"},
+			"timestamp":1718851200,
+			"start_timestamp":1718851200,
+			"level":"error",
+			"platform":"javascript",
+			"server_name":"test-server",
+			"release":"1.0.0",
+			"dist":"1.0.0",
+			"environment":"production",
+			"request":{"url":"https://test.com"},
+			"transaction":"test-transaction",
+			"modules":{"key":"value"},
+			"fingerprint":["test-fingerprint"],
+			"exception":{"values":[{"type":"Error","value":"Something went wrong"}]},
+			"breadcrumbs":[{"message":"Test breadcrumb"}],
+			"tags":{"key":"value"},
+			"extra":{"key":"value"}
+		}`)
+		addons := ComposeAddons(event)
+		assert.Equal(t, "Test message", addons["message"])
+		assert.Equal(t, "error", addons["level"])
+		assert.Equal(t, "javascript", addons["platform"])
+		assert.NotContains(t, addons, "release")
+		assert.NotContains(t, addons, "exception")
+		assert.NotContains(t, addons, "breadcrumbs")
+	})
+
+	t.Run("excludes undefined fields", func(t *testing.T) {
+		addons := ComposeAddons(gjson.Parse(`{"message":"Test message"}`))
+		assert.Equal(t, map[string]interface{}{"message": "Test message"}, addons)
+	})
+}
+
+func TestComposeUserData(t *testing.T) {
+	t.Run("compose user", func(t *testing.T) {
+		event := gjson.Parse(`{"user":{"id":"123","username":"testuser","email":"test@example.com"}}`)
+		assert.Equal(t, &HawkUser{ID: "123", Name: "testuser", URL: "test@example.com"}, ComposeUserData(event))
+	})
+
+	t.Run("missing user", func(t *testing.T) {
+		assert.Nil(t, ComposeUserData(gjson.Parse(`{}`)))
+	})
+
+	t.Run("missing user id", func(t *testing.T) {
+		event := gjson.Parse(`{"user":{"username":"testuser","email":"test@example.com"}}`)
+		assert.Equal(t, &HawkUser{ID: "unknown", Name: "testuser", URL: "test@example.com"}, ComposeUserData(event))
+	})
+}
+
+func TestIsJsSDK(t *testing.T) {
+	assert.True(t, IsJsSDK(gjson.Parse(`{"sdk":{"name":"browser"}}`)))
+	assert.True(t, IsJsSDK(gjson.Parse(`{"sdk":{"name":"sentry.javascript.react"}}`)))
+	assert.False(t, IsJsSDK(gjson.Parse(`{"sdk":{"name":"python"}}`)))
+	assert.False(t, IsJsSDK(gjson.Parse(`{}`)))
+}

--- a/pkg/sentry/envelope.go
+++ b/pkg/sentry/envelope.go
@@ -1,0 +1,148 @@
+package sentry
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Envelope is a parsed Sentry envelope: headers plus items.
+type Envelope struct {
+	Headers json.RawMessage
+	Items   []EnvelopeItem
+}
+
+// EnvelopeItem is a single envelope item (header + raw JSON payload).
+type EnvelopeItem struct {
+	Header  map[string]interface{}
+	Payload json.RawMessage // nil if missing
+}
+
+// FilterOutBinaryItems strips replay / binary lines that would crash envelope parsing.
+// Port of workers/sentry filterOutBinaryItems — keep behavior identical.
+func FilterOutBinaryItems(rawEvent string) string {
+	lines := strings.Split(rawEvent, "\n")
+	filteredLines := make([]string, 0, len(lines))
+	isInReplayBlock := false
+
+	for i, line := range lines {
+		// Keep envelope header (first line)
+		if i == 0 {
+			filteredLines = append(filteredLines, line)
+			continue
+		}
+
+		// Skip empty lines
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		var parsed map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &parsed); err != nil {
+			// If line doesn't parse as JSON, it might be binary data
+			// If we're in a replay block, skip it (it's part of replay recording)
+			if isInReplayBlock {
+				continue
+			}
+			// If not in replay block and not JSON, it might be corrupted data - skip it
+			continue
+		}
+
+		itemType, _ := parsed["type"].(string)
+
+		// Check if this is a replay event type
+		if itemType == "replay_recording" || itemType == "replay_event" {
+			isInReplayBlock = true
+			continue
+		}
+
+		// If we're in a replay block, check if this is still part of it
+		if isInReplayBlock {
+			_, hasSegmentID := parsed["segment_id"]
+			_, hasLength := parsed["length"]
+			_, hasReplayID := parsed["replay_id"]
+
+			if hasSegmentID || (hasLength && itemType != "event") || hasReplayID {
+				continue
+			}
+
+			// If it's a new envelope item (like event), we've exited the replay block
+			if itemType == "event" || itemType == "transaction" || itemType == "session" {
+				isInReplayBlock = false
+			} else {
+				// Unknown type, assume we're still in replay block
+				continue
+			}
+		}
+
+		// Keep valid headers and other JSON data (not in replay block)
+		if !isInReplayBlock {
+			filteredLines = append(filteredLines, line)
+		}
+	}
+
+	return strings.Join(filteredLines, "\n")
+}
+
+// ParseEnvelope parses a newline-delimited Sentry envelope after binary filtering.
+func ParseEnvelope(raw []byte) (*Envelope, error) {
+	filtered := FilterOutBinaryItems(string(raw))
+	lines := splitNonEmptyLines(filtered)
+	if len(lines) == 0 {
+		return nil, fmt.Errorf("empty envelope")
+	}
+
+	if !json.Valid([]byte(lines[0])) {
+		return nil, fmt.Errorf("failed to parse envelope header: invalid JSON")
+	}
+
+	items := make([]EnvelopeItem, 0)
+	for i := 1; i < len(lines); {
+		var itemHeader map[string]interface{}
+		if err := json.Unmarshal([]byte(lines[i]), &itemHeader); err != nil {
+			return nil, fmt.Errorf("failed to parse item header at line %d: %w", i, err)
+		}
+		i++
+
+		var payload json.RawMessage
+		if i < len(lines) {
+			rawPayload := []byte(lines[i])
+			if !json.Valid(rawPayload) {
+				return nil, fmt.Errorf("failed to parse item payload at line %d: invalid JSON", i)
+			}
+			payload = json.RawMessage(rawPayload)
+			i++
+		}
+
+		items = append(items, EnvelopeItem{
+			Header:  itemHeader,
+			Payload: payload,
+		})
+	}
+
+	return &Envelope{
+		Headers: json.RawMessage(lines[0]),
+		Items:   items,
+	}, nil
+}
+
+func splitNonEmptyLines(s string) []string {
+	raw := strings.Split(s, "\n")
+	out := make([]string, 0, len(raw))
+	for _, line := range raw {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+// ItemType returns the envelope item type from its header.
+func (item EnvelopeItem) ItemType() string {
+	if item.Header == nil {
+		return ""
+	}
+	t, _ := item.Header["type"].(string)
+	return t
+}

--- a/pkg/sentry/envelope.go
+++ b/pkg/sentry/envelope.go
@@ -1,6 +1,7 @@
 package sentry
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -12,7 +13,9 @@ type Envelope struct {
 	Items   []EnvelopeItem
 }
 
-// EnvelopeItem is a single envelope item (header + raw JSON payload).
+// EnvelopeItem is a single envelope item (header + raw payload bytes).
+// Payload is nil if missing. For event items the bytes are JSON, whether the
+// wire form was newline-delimited JSON or length-prefixed ("binary") payload.
 type EnvelopeItem struct {
 	Header  map[string]interface{}
 	Payload json.RawMessage // nil if missing
@@ -20,6 +23,7 @@ type EnvelopeItem struct {
 
 // FilterOutBinaryItems strips replay / binary lines that would crash envelope parsing.
 // Port of workers/sentry filterOutBinaryItems — keep behavior identical.
+// Prefer ParseEnvelope for full envelopes: it is length-aware and skips replays itself.
 func FilterOutBinaryItems(rawEvent string) string {
 	lines := strings.Split(rawEvent, "\n")
 	filteredLines := make([]string, 0, len(lines))
@@ -40,7 +44,7 @@ func FilterOutBinaryItems(rawEvent string) string {
 		var parsed map[string]interface{}
 		if err := json.Unmarshal([]byte(line), &parsed); err != nil {
 			// If line doesn't parse as JSON, it is likely an item payload (e.g., attachment/binary).
- 			// Keep it unless we're inside a replay block (replay recordings can include raw binary/newlines).
+			// Keep it unless we're inside a replay block (replay recordings can include raw binary/newlines).
 			if isInReplayBlock {
 				continue
 			}
@@ -84,35 +88,82 @@ func FilterOutBinaryItems(rawEvent string) string {
 	return strings.Join(filteredLines, "\n")
 }
 
-// ParseEnvelope parses a newline-delimited Sentry envelope after binary filtering.
+// ParseEnvelope parses a Sentry envelope.
+// Item payloads support both wire forms used by Sentry SDKs:
+//   - newline-delimited JSON (no "length" in the item header)
+//   - length-prefixed bytes (item header has numeric "length")
+// Replay items are skipped (same outcome as FilterOutBinaryItems).
 func ParseEnvelope(raw []byte) (*Envelope, error) {
-	filtered := FilterOutBinaryItems(string(raw))
-	lines := splitNonEmptyLines(filtered)
-	if len(lines) == 0 {
+	data := skipLeadingNewlines(raw)
+	if len(data) == 0 {
 		return nil, fmt.Errorf("empty envelope")
 	}
 
-	if !json.Valid([]byte(lines[0])) {
+	headerBytes, rest, err := readLine(data)
+	if err != nil || len(bytes.TrimSpace(headerBytes)) == 0 {
+		return nil, fmt.Errorf("empty envelope")
+	}
+	if !json.Valid(headerBytes) {
 		return nil, fmt.Errorf("failed to parse envelope header: invalid JSON")
 	}
 
 	items := make([]EnvelopeItem, 0)
-	for i := 1; i < len(lines); {
-		var itemHeader map[string]interface{}
-		if err := json.Unmarshal([]byte(lines[i]), &itemHeader); err != nil {
-			return nil, fmt.Errorf("failed to parse item header at line %d: %w", i, err)
-		}
-		i++
+	isInReplayBlock := false
 
-		var payload json.RawMessage
-		if i < len(lines) {
-			rawPayload := []byte(lines[i])
-			if !json.Valid(rawPayload) {
-				return nil, fmt.Errorf("failed to parse item payload at line %d: invalid JSON", i)
-			}
-			payload = json.RawMessage(rawPayload)
-			i++
+	for len(bytes.TrimSpace(rest)) > 0 {
+		rest = skipLeadingNewlines(rest)
+		if len(rest) == 0 {
+			break
 		}
+
+		headerLine, next, lineErr := readLine(rest)
+		if lineErr != nil {
+			return nil, fmt.Errorf("failed to read item header: %w", lineErr)
+		}
+
+		var itemHeader map[string]interface{}
+		if err := json.Unmarshal(headerLine, &itemHeader); err != nil {
+			// Non-JSON line: treat like FilterOutBinaryItems (skip in replay, else error)
+			if isInReplayBlock {
+				rest = next
+				continue
+			}
+			return nil, fmt.Errorf("failed to parse item header: %w", err)
+		}
+		rest = next
+
+		itemType, _ := itemHeader["type"].(string)
+		skip := false
+
+		if itemType == "replay_recording" || itemType == "replay_event" {
+			isInReplayBlock = true
+			skip = true
+		} else if isInReplayBlock {
+			_, hasSegmentID := itemHeader["segment_id"]
+			_, hasLength := itemHeader["length"]
+			_, hasReplayID := itemHeader["replay_id"]
+
+			if hasSegmentID || (hasLength && itemType != "event") || hasReplayID {
+				skip = true
+			} else if itemType == "event" || itemType == "transaction" || itemType == "session" {
+				isInReplayBlock = false
+			} else {
+				skip = true
+			}
+		}
+
+		if skip {
+			// Replay/binary stubs in tests often declare a large length but only
+			// include a short payload — consume what we can and continue.
+			rest = consumeItemPayloadBestEffort(rest, itemHeader)
+			continue
+		}
+
+		payload, next, err := readItemPayload(rest, itemHeader)
+		if err != nil {
+			return nil, err
+		}
+		rest = next
 
 		items = append(items, EnvelopeItem{
 			Header:  itemHeader,
@@ -121,21 +172,110 @@ func ParseEnvelope(raw []byte) (*Envelope, error) {
 	}
 
 	return &Envelope{
-		Headers: json.RawMessage(lines[0]),
+		Headers: json.RawMessage(headerBytes),
 		Items:   items,
 	}, nil
 }
 
-func splitNonEmptyLines(s string) []string {
-	raw := strings.Split(s, "\n")
-	out := make([]string, 0, len(raw))
-	for _, line := range raw {
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-		out = append(out, line)
+// readItemPayload reads the payload for one envelope item.
+// If the header has a numeric "length", exactly that many bytes are taken
+// (length-prefixed / "binary" form). Otherwise the next newline-terminated
+// line is taken as JSON.
+func readItemPayload(data []byte, header map[string]interface{}) (json.RawMessage, []byte, error) {
+	if len(data) == 0 {
+		return nil, data, nil
 	}
-	return out
+
+	if n, ok := headerLength(header); ok {
+		if n < 0 {
+			return nil, nil, fmt.Errorf("invalid item payload length: %d", n)
+		}
+		if len(data) < n {
+			return nil, nil, fmt.Errorf("item payload shorter than declared length: need %d, have %d", n, len(data))
+		}
+		payload := data[:n]
+		rest := data[n:]
+		if len(rest) > 0 && rest[0] == '\n' {
+			rest = rest[1:]
+		}
+		return json.RawMessage(payload), rest, nil
+	}
+
+	line, rest, err := readLine(data)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read item payload: %w", err)
+	}
+	if len(line) == 0 {
+		return nil, rest, nil
+	}
+	return json.RawMessage(line), rest, nil
+}
+
+// consumeItemPayloadBestEffort advances past an item payload without failing when
+// the declared length exceeds the remaining buffer (common for truncated replay stubs).
+func consumeItemPayloadBestEffort(data []byte, header map[string]interface{}) []byte {
+	if len(data) == 0 {
+		return data
+	}
+	if n, ok := headerLength(header); ok && n >= 0 {
+		if len(data) < n {
+			return nil
+		}
+		rest := data[n:]
+		if len(rest) > 0 && rest[0] == '\n' {
+			rest = rest[1:]
+		}
+		return rest
+	}
+	_, rest, err := readLine(data)
+	if err != nil {
+		return nil
+	}
+	return rest
+}
+
+func headerLength(header map[string]interface{}) (int, bool) {
+	if header == nil {
+		return 0, false
+	}
+	raw, ok := header["length"]
+	if !ok || raw == nil {
+		return 0, false
+	}
+	switch v := raw.(type) {
+	case float64:
+		return int(v), true
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(n), true
+	case int:
+		return v, true
+	case int64:
+		return int(v), true
+	default:
+		return 0, false
+	}
+}
+
+func readLine(data []byte) ([]byte, []byte, error) {
+	if len(data) == 0 {
+		return nil, data, fmt.Errorf("unexpected end of envelope")
+	}
+	idx := bytes.IndexByte(data, '\n')
+	if idx < 0 {
+		return data, nil, nil
+	}
+	return data[:idx], data[idx+1:], nil
+}
+
+func skipLeadingNewlines(data []byte) []byte {
+	for len(data) > 0 && (data[0] == '\n' || data[0] == '\r') {
+		data = data[1:]
+	}
+	return data
 }
 
 // ItemType returns the envelope item type from its header.

--- a/pkg/sentry/envelope.go
+++ b/pkg/sentry/envelope.go
@@ -39,12 +39,12 @@ func FilterOutBinaryItems(rawEvent string) string {
 
 		var parsed map[string]interface{}
 		if err := json.Unmarshal([]byte(line), &parsed); err != nil {
-			// If line doesn't parse as JSON, it might be binary data
-			// If we're in a replay block, skip it (it's part of replay recording)
+			// If line doesn't parse as JSON, it is likely an item payload (e.g., attachment/binary).
+ 			// Keep it unless we're inside a replay block (replay recordings can include raw binary/newlines).
 			if isInReplayBlock {
 				continue
 			}
-			// If not in replay block and not JSON, it might be corrupted data - skip it
+			filteredLines = append(filteredLines, line)
 			continue
 		}
 

--- a/pkg/sentry/process.go
+++ b/pkg/sentry/process.go
@@ -1,0 +1,96 @@
+package sentry
+
+import (
+	"encoding/json"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+)
+
+// ProcessResult is the outcome of processing one envelope item.
+type ProcessResult string
+
+const (
+	ProcessResultProcessed ProcessResult = "processed"
+	ProcessResultSkipped   ProcessResult = "skipped"
+)
+
+// ProcessEnvelope parses a raw Sentry envelope and transforms event items into Hawk messages.
+// Non-event items are skipped (client_report is logged then skipped). Same behavior as the Node worker.
+func ProcessEnvelope(raw []byte, projectID string) ([]*HawkBrokerPayload, error) {
+	envelope, err := ParseEnvelope(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(envelope.Items) == 0 {
+		log.Warn("Received envelope with no items")
+		return nil, nil
+	}
+
+	messages := make([]*HawkBrokerPayload, 0)
+	processedCount := 0
+	skippedCount := 0
+
+	for _, item := range envelope.Items {
+		result, msg, err := handleEnvelopeItem(envelope.Headers, item, projectID)
+		if err != nil {
+			return nil, err
+		}
+		switch result {
+		case ProcessResultProcessed:
+			processedCount++
+			messages = append(messages, msg)
+		case ProcessResultSkipped:
+			skippedCount++
+		}
+	}
+
+	log.Debugf("Processed %d events, skipped %d non-event items from envelope", processedCount, skippedCount)
+	return messages, nil
+}
+
+func handleEnvelopeItem(envelopeHeaders json.RawMessage, item EnvelopeItem, projectID string) (ProcessResult, *HawkBrokerPayload, error) {
+	// Same as Node: missing / null payload is an error for any item type
+	if item.Payload == nil || len(item.Payload) == 0 || string(item.Payload) == "null" {
+		return "", nil, fmt.Errorf("Item payload is missing")
+	}
+
+	itemType := item.ItemType()
+	if itemType != "event" {
+		if itemType == "client_report" {
+			logClientReport(envelopeHeaders, item)
+		}
+		log.Infof("Skipping non-event item of type: %s", itemType)
+		return ProcessResultSkipped, nil, nil
+	}
+
+	msg, err := TransformToHawkFormat(envelopeHeaders, item, projectID)
+	if err != nil {
+		return "", nil, err
+	}
+	return ProcessResultProcessed, msg, nil
+}
+
+func logClientReport(envelopeHeaders json.RawMessage, item EnvelopeItem) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Warnf("Failed to decode/log client_report item: %v", r)
+			log.Infof("👇 Here is the raw client_report item: header=%v payload=%s", item.Header, string(item.Payload))
+		}
+	}()
+
+	var decoded interface{}
+	if err := json.Unmarshal(item.Payload, &decoded); err != nil {
+		decoded = string(item.Payload)
+	}
+
+	log.Info("Received client_report item; logging internals:")
+	log.Infof("envelopeHeaders=%s itemHeader=%v payload=%v", string(envelopeHeaders), item.Header, decoded)
+
+	// Also surface structured fields when present (helps debugging)
+	if gjson.GetBytes(item.Payload, "discarded_events").Exists() {
+		log.Debugf("client_report discarded_events=%s", gjson.GetBytes(item.Payload, "discarded_events").Raw)
+	}
+}

--- a/pkg/sentry/process.go
+++ b/pkg/sentry/process.go
@@ -53,7 +53,7 @@ func ProcessEnvelope(raw []byte, projectID string) ([]*HawkBrokerPayload, error)
 
 func handleEnvelopeItem(envelopeHeaders json.RawMessage, item EnvelopeItem, projectID string) (ProcessResult, *HawkBrokerPayload, error) {
 	// Same as Node: missing / null payload is an error for any item type
-	if item.Payload == nil || len(item.Payload) == 0 || string(item.Payload) == "null" {
+	if len(item.Payload) == 0 || string(item.Payload) == "null" {
 		return "", nil, fmt.Errorf("Item payload is missing")
 	}
 

--- a/pkg/sentry/process.go
+++ b/pkg/sentry/process.go
@@ -62,7 +62,7 @@ func handleEnvelopeItem(envelopeHeaders json.RawMessage, item EnvelopeItem, proj
 		if itemType == "client_report" {
 			logClientReport(envelopeHeaders, item)
 		}
-		log.Infof("Skipping non-event item of type: %s", itemType)
+		log.Debugf("Skipping non-event item of type: %s", itemType)
 		return ProcessResultSkipped, nil, nil
 	}
 
@@ -86,8 +86,8 @@ func logClientReport(envelopeHeaders json.RawMessage, item EnvelopeItem) {
 		decoded = string(item.Payload)
 	}
 
-	log.Info("Received client_report item; logging internals:")
-	log.Infof("envelopeHeaders=%s itemHeader=%v payload=%v", string(envelopeHeaders), item.Header, decoded)
+	log.Debugf("Received client_report item; logging internals:")
+	log.Debugf("envelopeHeaders=%s itemHeader=%v payload=%v", string(envelopeHeaders), item.Header, decoded)
 
 	// Also surface structured fields when present (helps debugging)
 	if gjson.GetBytes(item.Payload, "discarded_events").Exists() {

--- a/pkg/sentry/process_test.go
+++ b/pkg/sentry/process_test.go
@@ -1,0 +1,209 @@
+package sentry
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessEnvelope_MultipleEvents(t *testing.T) {
+	envelope := joinLines(
+		`{"event_id":"123e4567-e89b-12d3-a456-426614174000","sent_at":"2024-01-01T00:00:00.000Z"}`,
+		`{"type":"event","content_type":"application/json"}`,
+		`{"level":"error","message":"Error 1"}`,
+		`{"type":"event","content_type":"application/json"}`,
+		`{"level":"warning","message":"Warning 1"}`,
+	)
+
+	messages, err := ProcessEnvelope([]byte(envelope), "123")
+	require.NoError(t, err)
+	require.Len(t, messages, 2)
+	assert.Equal(t, "error", messages[0].Payload.Type)
+	assert.Equal(t, "warning", messages[1].Payload.Type)
+	assert.Equal(t, CatcherTypeDefault, messages[0].CatcherType)
+}
+
+func TestProcessEnvelope_EmptyItems(t *testing.T) {
+	envelope := `{"event_id":"123e4567-e89b-12d3-a456-426614174000","sent_at":"2024-01-01T00:00:00.000Z"}`
+	messages, err := ProcessEnvelope([]byte(envelope), "123")
+	require.NoError(t, err)
+	assert.Empty(t, messages)
+}
+
+func TestProcessEnvelope_SkipsNonEventItems(t *testing.T) {
+	envelope := joinLines(
+		`{"event_id":"123e4567-e89b-12d3-a456-426614174000","sent_at":"2024-01-01T00:00:00.000Z"}`,
+		`{"type":"transaction"}`,
+		`{"name":"Test Transaction"}`,
+		`{"type":"attachment"}`,
+		`{"filename":"test.txt"}`,
+		`{"type":"client_report"}`,
+		`{"timestamp":1718534400,"discarded_events":[]}`,
+	)
+
+	messages, err := ProcessEnvelope([]byte(envelope), "123")
+	require.NoError(t, err)
+	assert.Empty(t, messages)
+}
+
+func TestProcessEnvelope_MissingPayload(t *testing.T) {
+	envelope := joinLines(
+		`{"event_id":"123e4567-e89b-12d3-a456-426614174000","sent_at":"2024-01-01T00:00:00.000Z"}`,
+		`{"type":"event"}`,
+		`null`,
+	)
+
+	_, err := ProcessEnvelope([]byte(envelope), "123")
+	require.Error(t, err)
+}
+
+func TestProcessEnvelope_TimestampFormats(t *testing.T) {
+	timestamps := []string{
+		"2024-01-01T00:00:00.000Z",
+		"2024-01-01T00:00:00Z",
+		"2024-01-01T00:00:00.000+00:00",
+	}
+
+	for _, ts := range timestamps {
+		envelope := joinLines(
+			`{"event_id":"123e4567-e89b-12d3-a456-426614174000","sent_at":"`+ts+`"}`,
+			`{"type":"event"}`,
+			`{"message":"Test timestamp"}`,
+		)
+		messages, err := ProcessEnvelope([]byte(envelope), "123")
+		require.NoError(t, err, ts)
+		require.Len(t, messages, 1)
+		assert.Equal(t, int64(1704067200), messages[0].Timestamp, ts)
+		assert.Equal(t, "Test timestamp", messages[0].Payload.Title)
+		assert.Equal(t, CatcherVersion, messages[0].Payload.CatcherVersion)
+	}
+}
+
+func TestProcessEnvelope_RoutesJsSDK(t *testing.T) {
+	envelope := joinLines(
+		`{"event_id":"123e4567-e89b-12d3-a456-426614174000","sent_at":"2024-01-01T00:00:00.000Z"}`,
+		`{"type":"event"}`,
+		`{"sdk":{"name":"browser"},"release":"1.0.0"}`,
+	)
+	messages, err := ProcessEnvelope([]byte(envelope), "123")
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, CatcherTypeJavaScript, messages[0].CatcherType)
+	assert.Equal(t, "1.0.0", messages[0].Payload.Release)
+}
+
+func TestProcessEnvelope_RoutesNonJsSDK(t *testing.T) {
+	envelope := joinLines(
+		`{"event_id":"123e4567-e89b-12d3-a456-426614174000","sent_at":"2024-01-01T00:00:00.000Z"}`,
+		`{"type":"event"}`,
+		`{"sdk":{"name":"python"},"release":"1.0.0"}`,
+	)
+	messages, err := ProcessEnvelope([]byte(envelope), "123")
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, CatcherTypeDefault, messages[0].CatcherType)
+}
+
+func TestProcessEnvelope_ReleasePreference(t *testing.T) {
+	envelope := joinLines(
+		`{"event_id":"123","sent_at":"2024-01-01T00:00:00.000Z","trace":{"release":"1.0.0"}}`,
+		`{"type":"event"}`,
+		`{"release":"1.0.1"}`,
+	)
+	messages, err := ProcessEnvelope([]byte(envelope), "123")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.1", messages[0].Payload.Release)
+}
+
+func TestProcessEnvelope_ReleaseFromTrace(t *testing.T) {
+	envelope := joinLines(
+		`{"event_id":"123","sent_at":"2024-01-01T00:00:00.000Z","trace":{"release":"1.0.0"}}`,
+		`{"type":"event"}`,
+		`{"message":"Test"}`,
+	)
+	messages, err := ProcessEnvelope([]byte(envelope), "123")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.0", messages[0].Payload.Release)
+}
+
+func TestProcessEnvelope_FiltersReplayOnly(t *testing.T) {
+	envelope := joinLines(
+		`{"event_id":"62680958b3ab4497886375e06533d86a","sent_at":"2025-12-24T13:16:34.580Z","sdk":{"name":"sentry.javascript.react"}}`,
+		`{"type":"replay_event"}`,
+		`{"type":"replay_event","replay_id":"62680958b3ab4497886375e06533d86a","segment_id":1}`,
+		`{"type":"replay_recording","length":16385}`,
+		`{"segment_id":1}`,
+		`xnFWy@v$xAlJ=&fS~binary`,
+	)
+	messages, err := ProcessEnvelope([]byte(envelope), "123")
+	require.NoError(t, err)
+	assert.Empty(t, messages)
+}
+
+func TestProcessEnvelope_MixedEventAndReplay(t *testing.T) {
+	envelope := joinLines(
+		`{"event_id":"4c40fee730194a989439a86bf75634111","sent_at":"2025-08-29T10:59:29.952Z","sdk":{"name":"sentry.javascript.react"}}`,
+		`{"type":"event"}`,
+		`{"message":"Test event","level":"error"}`,
+		`{"type":"replay_event"}`,
+		`{"replay_id":"test-replay","segment_id":1}`,
+		`{"type":"replay_recording","length":343}`,
+		`binary-data-here-that-is-not-json`,
+	)
+	messages, err := ProcessEnvelope([]byte(envelope), "621601f4a010d35c68b4625a")
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	// SDK is only on envelope header; Node routes by item payload.sdk → default
+	assert.Equal(t, CatcherTypeDefault, messages[0].CatcherType)
+	require.NotNil(t, messages[0].Payload.Addons)
+	sentryAddons := messages[0].Payload.Addons["sentry"].(map[string]interface{})
+	assert.Equal(t, "Test event", sentryAddons["message"])
+	assert.Equal(t, "error", sentryAddons["level"])
+}
+
+func TestProcessEnvelope_RealPythonError(t *testing.T) {
+	b64 := "eyJldmVudF9pZCI6ImE3OWVhYjNmY2ZjMDQ1ZjM5MTUyNzM5NWJmYzhlZGM2Iiwic2VudF9hdCI6IjIwMjQtMTItMThUMTQ6MDA6MTIuODY2NjYwWiIsInRyYWNlIjp7InRyYWNlX2lkIjoiYTAwMDA1NzEwOGFlNDJhMGIxNTRhY2ZmN2U5YTUxMTQiLCJlbnZpcm9ubWVudCI6InByb2R1Y3Rpb24iLCJyZWxlYXNlIjoiMzVjNDJmMmRkZjUyNGJiZGFmZTIyNDM5Yjk4MWRkZmQwZmIzYjVhZCIsInB1YmxpY19rZXkiOiIyMGRlYTRjN2NmZjg0NWZlYmE3YWJmNDlhYzZhOTdlZWFiMTg4NDNhOTczNDRmODZhY2QzNGM3MzAxNDc3YTQxIn19CnsidHlwZSI6ImV2ZW50IiwiY29udGVudF90eXBlIjoiYXBwbGljYXRpb24vanNvbiIsImxlbmd0aCI6MTk5MH0KeyJsZXZlbCI6ImVycm9yIiwiZXhjZXB0aW9uIjp7InZhbHVlcyI6W3sibWVjaGFuaXNtIjp7InR5cGUiOiJleGNlcHRob29rIiwiaGFuZGxlZCI6ZmFsc2V9LCJtb2R1bGUiOm51bGwsInR5cGUiOiJaZXJvRGl2aXNpb25FcnJvciIsInZhbHVlIjoiZGl2aXNpb24gYnkgemVybyIsInN0YWNrdHJhY2UiOnsiZnJhbWVzIjpbeyJmaWxlbmFtZSI6InNlbnRyeS1wcm9kLnB5IiwiYWJzX3BhdGgiOiIvVXNlcnMvbm9zdHIvZGV2L2NvZGV4L2hhd2subW9uby90ZXN0cy9tYW51YWwvc2VudHJ5L3NlbnRyeS1wcm9kLnB5IiwiZnVuY3Rpb24iOiI8bW9kdWxlPiIsIm1vZHVsZSI6Il9fbWFpbl9fIiwibGluZW5vIjoxMSwicHJlX2NvbnRleHQiOlsiIiwic2VudHJ5X3Nkay5pbml0KCIsIiAgICBkc249ZlwiaHR0cHM6Ly97SEFXS19JTlRFR1JBVElPTl9UT0tFTn1Ae0hPU1R9LzBcIiwiLCIgICAgZGVidWc9VHJ1ZSIsIikiXSwiY29udGV4dF9saW5lIjoiZGl2aXNpb25fYnlfemVybyA9IDEgLyAwIiwicG9zdF9jb250ZXh0IjpbInByaW50KFwidGhpc1wiKSIsInByaW50KFwiaXNcIikiLCJwcmludChcIm9rXCIpIiwiIyByYWlzZSBFeGNlcHRpb24oXCJUaGlzIGlzIGEgdGVzdCBleGNlcHRpb25cIikiXSwidmFycyI6eyJfX25hbWVfXyI6IidfX21haW5fXyciLCJfX2RvY19fIjoiTm9uZSIsIl9fcGFja2FnZV9fIjoiTm9uZSIsIl9fbG9hZGVyX18iOiI8X2Zyb3plbl9pbXBvcnRsaWJfZXh0ZXJuYWwuU291cmNlRmlsZUxvYWRlciBvYmplY3QgYXQgMHgxMDI5MzRjYjA+IiwiX19zcGVjX18iOiJOb25lIiwiX19hbm5vdGF0aW9uc19fIjp7fSwiX19idWlsdGluc19fIjoiPG1vZHVsZSAnYnVpbHRpbnMnIChidWlsdC1pbik+IiwiX19maWxlX18iOiInL1VzZXJzL25vc3RyL2Rldi9jb2RleC9oYXdrLm1vbm8vdGVzdHMvbWFudWFsL3NlbnRyeS9zZW50cnktcHJvZC5weSciLCJfX2NhY2hlZF9fIjoiTm9uZSIsInNlbnRyeV9zZGsiOiI8bW9kdWxlICdzZW50cnlfc2RrJyBmcm9tICcvVXNlcnMvbm9zdHIvZGV2L2NvZGV4L2hhd2subW9uby8udmVudi9saWIvcHl0aG9uMy4xMy9zaXRlLXBhY2thZ2VzL3NlbnRyeV9zZGsvX19pbml0X18ucHknPiJ9LCJpbl9hcHAiOnRydWV9XX19XX0sImV2ZW50X2lkIjoiYTc5ZWFiM2ZjZmMwNDVmMzkxNTI3Mzk1YmZjOGVkYzYiLCJ0aW1lc3RhbXAiOiIyMDI0LTEyLTE4VDE0OjAwOjEyLjg2MzY4NFoiLCJjb250ZXh0cyI6eyJ0cmFjZSI6eyJ0cmFjZV9pZCI6ImEwMDAwNTcxMDhhZTQyYTBiMTU0YWNmZjdlOWE1MTE0Iiwic3Bhbl9pZCI6ImFmNzI2MjMwODk4ODJiNjciLCJwYXJlbnRfc3Bhbl9pZCI6bnVsbH0sInJ1bnRpbWUiOnsibmFtZSI6IkNQeXRob24iLCJ2ZXJzaW9uIjoiMy4xMy4xIiwiYnVpbGQiOiIzLjEzLjEgKG1haW4sIERlYyAgMyAyMDI0LCAxNzo1OTo1MikgW0NsYW5nIDE2LjAuMCAoY2xhbmctMTYwMC4wLjI2LjQpXSJ9fSwidHJhbnNhY3Rpb25faW5mbyI6e30sImJyZWFkY3J1bWJzIjp7InZhbHVlcyI6W119LCJleHRyYSI6eyJzeXMuYXJndiI6WyJzZW50cnktcHJvZC5weSJdfSwibW9kdWxlcyI6eyJwaXAiOiIyNC4zLjEiLCJ1cmxsaWIzIjoiMi4yLjMiLCJzZW50cnktc2RrIjoiMi4xOS4wIiwiY2VydGlmaSI6IjIwMjQuOC4zMCJ9LCJyZWxlYXNlIjoiMzVjNDJmMmRkZjUyNGJiZGFmZTIyNDM5Yjk4MWRkZmQwZmIzYjVhZCIsImVudmlyb25tZW50IjoicHJvZHVjdGlvbiIsInNlcnZlcl9uYW1lIjoiTWFjQm9vay1Qcm8tQWxla3NhbmRyLTUubG9jYWwiLCJzZGsiOnsibmFtZSI6InNlbnRyeS5weXRob24iLCJ2ZXJzaW9uIjoiMi4xOS4wIiwicGFja2FnZXMiOlt7Im5hbWUiOiJweXBpOnNlbnRyeS1zZGsiLCJ2ZXJzaW9uIjoiMi4xOS4wIn1dLCJpbnRlZ3JhdGlvbnMiOlsiYXJndiIsImF0ZXhpdCIsImRlZHVwZSIsImV4Y2VwdGhvb2siLCJsb2dnaW5nIiwibW9kdWxlcyIsInN0ZGxpYiIsInRocmVhZGluZyJdfSwicGxhdGZvcm0iOiJweXRob24ifQo="
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	require.NoError(t, err)
+
+	messages, err := ProcessEnvelope(raw, "675c9605b8264d74b5a7dcf3")
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+
+	msg := messages[0]
+	assert.Equal(t, int64(1734530412), msg.Timestamp)
+	assert.Equal(t, CatcherTypeDefault, msg.CatcherType)
+	assert.Equal(t, "ZeroDivisionError: division by zero", msg.Payload.Title)
+	assert.Equal(t, "error", msg.Payload.Type)
+	assert.Equal(t, "35c42f2ddf524bbdafe22439b981ddfd0fb3b5ad", msg.Payload.Release)
+	assert.Equal(t, CatcherVersion, msg.Payload.CatcherVersion)
+	require.Len(t, msg.Payload.Backtrace, 1)
+	assert.Equal(t, "sentry-prod.py", msg.Payload.Backtrace[0].File)
+	assert.Equal(t, 11, msg.Payload.Backtrace[0].Line)
+	assert.Equal(t, "<module>", msg.Payload.Backtrace[0].Function)
+}
+
+func TestProcessEnvelope_CyrillicTitle(t *testing.T) {
+	envelope := joinLines(
+		`{"event_id":"4b6140fb97504945908fe52c5b0dd123","sent_at":"2025-04-03T13:27:27.348Z"}`,
+		`{"type":"event","content_type":"application/json"}`,
+		`{"exception":{"values":[{"type":"Exception","value":"Тестовая ошибка #287"}]},"sdk":{"name":"sentry.java.android"}}`,
+	)
+	messages, err := ProcessEnvelope([]byte(envelope), "67ed371b4196dcbd73537c64")
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "Exception: Тестовая ошибка #287", messages[0].Payload.Title)
+}
+
+func joinLines(lines ...string) string {
+	out := ""
+	for i, line := range lines {
+		if i > 0 {
+			out += "\n"
+		}
+		out += line
+	}
+	return out
+}

--- a/pkg/sentry/process_test.go
+++ b/pkg/sentry/process_test.go
@@ -2,6 +2,7 @@ package sentry
 
 import (
 	"encoding/base64"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,7 +23,7 @@ func TestProcessEnvelope_MultipleEvents(t *testing.T) {
 	require.Len(t, messages, 2)
 	assert.Equal(t, "error", messages[0].Payload.Type)
 	assert.Equal(t, "warning", messages[1].Payload.Type)
-	assert.Equal(t, CatcherTypeDefault, messages[0].CatcherType)
+	assert.Equal(t, WorkerTypeDefault, messages[0].CatcherType)
 }
 
 func TestProcessEnvelope_EmptyItems(t *testing.T) {
@@ -90,7 +91,7 @@ func TestProcessEnvelope_RoutesJsSDK(t *testing.T) {
 	messages, err := ProcessEnvelope([]byte(envelope), "123")
 	require.NoError(t, err)
 	require.Len(t, messages, 1)
-	assert.Equal(t, CatcherTypeJavaScript, messages[0].CatcherType)
+	assert.Equal(t, WorkerTypeJavaScript, messages[0].CatcherType)
 	assert.Equal(t, "1.0.0", messages[0].Payload.Release)
 }
 
@@ -103,7 +104,7 @@ func TestProcessEnvelope_RoutesNonJsSDK(t *testing.T) {
 	messages, err := ProcessEnvelope([]byte(envelope), "123")
 	require.NoError(t, err)
 	require.Len(t, messages, 1)
-	assert.Equal(t, CatcherTypeDefault, messages[0].CatcherType)
+	assert.Equal(t, WorkerTypeDefault, messages[0].CatcherType)
 }
 
 func TestProcessEnvelope_ReleasePreference(t *testing.T) {
@@ -156,7 +157,7 @@ func TestProcessEnvelope_MixedEventAndReplay(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, messages, 1)
 	// SDK is only on envelope header; Node routes by item payload.sdk → default
-	assert.Equal(t, CatcherTypeDefault, messages[0].CatcherType)
+	assert.Equal(t, WorkerTypeDefault, messages[0].CatcherType)
 	require.NotNil(t, messages[0].Payload.Addons)
 	sentryAddons := messages[0].Payload.Addons["sentry"].(map[string]interface{})
 	assert.Equal(t, "Test event", sentryAddons["message"])
@@ -174,7 +175,7 @@ func TestProcessEnvelope_RealPythonError(t *testing.T) {
 
 	msg := messages[0]
 	assert.Equal(t, int64(1734530412), msg.Timestamp)
-	assert.Equal(t, CatcherTypeDefault, msg.CatcherType)
+	assert.Equal(t, WorkerTypeDefault, msg.CatcherType)
 	assert.Equal(t, "ZeroDivisionError: division by zero", msg.Payload.Title)
 	assert.Equal(t, "error", msg.Payload.Type)
 	assert.Equal(t, "35c42f2ddf524bbdafe22439b981ddfd0fb3b5ad", msg.Payload.Release)
@@ -195,6 +196,35 @@ func TestProcessEnvelope_CyrillicTitle(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, messages, 1)
 	assert.Equal(t, "Exception: Тестовая ошибка #287", messages[0].Payload.Title)
+}
+
+func TestProcessEnvelope_JSONPayloadWithoutLength(t *testing.T) {
+	envelope := joinLines(
+		`{"event_id":"123e4567-e89b-12d3-a456-426614174000","sent_at":"2024-01-01T00:00:00.000Z"}`,
+		`{"type":"event","content_type":"application/json"}`,
+		`{"message":"plain json payload","level":"error"}`,
+	)
+	messages, err := ProcessEnvelope([]byte(envelope), "123")
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "plain json payload", messages[0].Payload.Title)
+	assert.Equal(t, "error", messages[0].Payload.Type)
+}
+
+func TestProcessEnvelope_LengthPrefixedPayload(t *testing.T) {
+	// Pretty-printed JSON contains real newlines; only length-aware parsing reads it correctly.
+	payload := "{\n  \"message\": \"pretty json payload\",\n  \"level\": \"error\"\n}"
+	header := fmt.Sprintf(`{"type":"event","content_type":"application/json","length":%d}`, len(payload))
+	envelope := joinLines(
+		`{"event_id":"123e4567-e89b-12d3-a456-426614174000","sent_at":"2024-01-01T00:00:00.000Z"}`,
+		header,
+	) + "\n" + payload + "\n"
+
+	messages, err := ProcessEnvelope([]byte(envelope), "123")
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "pretty json payload", messages[0].Payload.Title)
+	assert.Equal(t, "error", messages[0].Payload.Type)
 }
 
 func joinLines(lines ...string) string {

--- a/pkg/server/errorshandler/handler_sentry.go
+++ b/pkg/server/errorshandler/handler_sentry.go
@@ -3,26 +3,16 @@ package errorshandler
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/codex-team/hawk.collector/pkg/broker"
+	"github.com/codex-team/hawk.collector/pkg/sentry"
 	log "github.com/sirupsen/logrus"
 	"github.com/valyala/fasthttp"
 )
 
-const SentryQueueName = "external/sentry"
-const CatcherType = "external/sentry"
-
-// helper for CORS
-func allowCORS(ctx *fasthttp.RequestCtx) {
-	h := &ctx.Response.Header
-	h.Set("Access-Control-Allow-Origin", "*")
-	h.Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	h.Set("Access-Control-Allow-Headers", "Content-Type, X-Sentry-Auth")
-	h.Set("Access-Control-Max-Age", "86400")
-}
-
-// HandleHTTP processes HTTP requests with JSON body
+// HandleSentry processes Sentry envelope HTTP requests.
+// Parses the envelope, skips non-event items (no rate-limit / plot impact),
+// transforms events to Hawk format, and publishes to errors/javascript or errors/default.
 func (handler *Handler) HandleSentry(ctx *fasthttp.RequestCtx) {
 	if ctx.Request.Header.ContentLength() > handler.MaxErrorCatcherMessageSize {
 		handler.ErrorsRejectedMessageTooLarge.Inc()
@@ -94,6 +84,21 @@ func (handler *Handler) HandleSentry(ctx *fasthttp.RequestCtx) {
 	}
 	log.Debugf("Found project with ID %s for integration token %s", projectId, hawkToken)
 
+	// Parse + transform before rate-limiting so non-event-only envelopes
+	// do not affect rate limits or plots.
+	messages, err := sentry.ProcessEnvelope(sentryEnvelopeBody, projectId)
+	if err != nil {
+		log.Errorf("Error handling Sentry envelope: %v", err)
+		sendAnswerHTTP(ctx, ResponseMessage{400, true, "Failed to process Sentry envelope"})
+		return
+	}
+
+	if len(messages) == 0 {
+		// Non-event items only (or empty after filtering) — skip silently
+		sendAnswerHTTP(ctx, ResponseMessage{200, false, "OK"})
+		return
+	}
+
 	projectLimits, ok := handler.AccountsMongoDBClient.GetProjectLimits(projectId)
 	if !ok {
 		log.Warnf("Project %s is not in the projects limits cache", projectId)
@@ -121,31 +126,45 @@ func (handler *Handler) HandleSentry(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	// convert message to JSON format
-	rawMessage := RawSentryMessage{Envelope: sentryEnvelopeBody}
-	jsonMessage, err := json.Marshal(rawMessage)
-	if err != nil {
-		log.Errorf("Message marshalling error: %v", err)
-		sendAnswerHTTP(ctx, ResponseMessage{400, true, "Cannot serialize envelope"})
+	for _, msg := range messages {
+		payloadBytes, err := json.Marshal(msg.Payload)
+		if err != nil {
+			log.Errorf("Message marshalling error: %v", err)
+			sendAnswerHTTP(ctx, ResponseMessage{400, true, "Cannot serialize event payload"})
+			return
+		}
+
+		messageToSend := BrokerMessage{
+			Timestamp:   msg.Timestamp,
+			ProjectId:   msg.ProjectID,
+			Payload:     json.RawMessage(payloadBytes),
+			CatcherType: msg.CatcherType,
+		}
+		payloadToSend, err := json.Marshal(messageToSend)
+		if err != nil {
+			log.Errorf("Message marshalling error: %v", err)
+			sendAnswerHTTP(ctx, ResponseMessage{400, true, "Cannot serialize message"})
+			return
+		}
+
+		route := handler.determineQueue(msg.CatcherType)
+		brokerMessage := broker.Message{Payload: payloadToSend, Route: route}
+		log.Debugf("Send to queue: %s", brokerMessage)
+		handler.Broker.Chan <- brokerMessage
 	}
 
-	messageToSend := BrokerMessage{Timestamp: time.Now().Unix(), ProjectId: projectId, Payload: json.RawMessage(jsonMessage), CatcherType: CatcherType}
-	payloadToSend, err := json.Marshal(messageToSend)
-	if err != nil {
-		log.Errorf("Message marshalling error: %v", err)
-		sendAnswerHTTP(ctx, ResponseMessage{400, true, "Cannot serialize envelope"})
-	}
-
-	// send serialized message to a broker
-	brokerMessage := broker.Message{Payload: payloadToSend, Route: SentryQueueName}
-	log.Debugf("Send to queue: %s", brokerMessage)
-	handler.Broker.Chan <- brokerMessage
-
-	// increment processed errors counter
+	// One acceptance counter per HTTP request that yielded ≥1 event (same as before).
 	handler.ErrorsProcessed.Inc()
-
-	// record project metrics
 	handler.recordProjectMetrics(projectId, "events-accepted", true)
 
 	sendAnswerHTTP(ctx, ResponseMessage{200, false, "OK"})
+}
+
+// helper for CORS
+func allowCORS(ctx *fasthttp.RequestCtx) {
+	h := &ctx.Response.Header
+	h.Set("Access-Control-Allow-Origin", "*")
+	h.Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	h.Set("Access-Control-Allow-Headers", "Content-Type, X-Sentry-Auth")
+	h.Set("Access-Control-Max-Age", "86400")
 }

--- a/pkg/server/errorshandler/messages.go
+++ b/pkg/server/errorshandler/messages.go
@@ -23,9 +23,5 @@ type BrokerMessage struct {
 	ProjectId   string          `json:"projectId"`
 	Payload     json.RawMessage `json:"payload"`
 	CatcherType string          `json:"catcherType"`
-	Timestamp int64             `json:"timestamp"`
-}
-
-type RawSentryMessage struct {
-	Envelope []byte `json:"envelope"`
+	Timestamp   int64           `json:"timestamp"`
 }


### PR DESCRIPTION
This merge requests solves the issue of sentry events filling in rate-limiting counter in redis

now we parse sentry events on collector side and proceed without processing via separate sentry worker

